### PR TITLE
Update Node.js to 20 and Upgrade VTEX CLI to 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ jobs:
                                     # any of account, appKey or appToken is missing
           workspace: master         # defaults to master
           bin: vtex                 # defaults to vtex
-          version: 3.0.0-beta-ci.3  # defaults to 3.0.0-beta-ci.3
+          version: 4.1.0            # defaults to 4.1.0
 
       - name: Do something after the login
         # The call name bellow must be the same given as *with: bin*

--- a/action.yml
+++ b/action.yml
@@ -36,9 +36,10 @@ runs:
       shell: bash
 
     - name: "Set up Node.js"
-      uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+      uses: actions/setup-node@v4
       with:
         cache: yarn
+        node-version: 20
 
     - name: "Install VTEX Toolbelt"
       run: |

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
   version:
     description: "Version of VTEX Toolbelt to be installed"
     required: false
-    default: 3.0.0-beta-ci.3
+    default: 4.1.0
 
 runs:
   using: "composite"


### PR DESCRIPTION
### Description

This pull request updates the `vtex/action-toolbelt` GitHub Action to support Node.js 20 and also upgrades the VTEX CLI from version `3.0.0-beta-ci.3` to `4.1.0`.

### Changes

- **Node.js Version**: Upgraded the Node.js version used by the action from `16` to `20` to comply with GitHub Actions' new default environment.
- **VTEX CLI**: Updated the default VTEX CLI version from `3.0.0-beta-ci.3` to `4.1.0` to leverage the latest features and improvements.

### Motivation

GitHub Actions has announced that all actions will be forced to run on Node.js 20 starting March 7, 2024, due to the deprecation of Node.js 16. To ensure our workflows continue to function smoothly and take advantage of the latest updates, this PR makes the necessary adjustments.

### References

- [GitHub Actions Node.js 20 Update Announcement](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
